### PR TITLE
Test Loki client integration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ clean:
 .PHONY: lint
 lint:
 	mypy function_app.py logexport
-	isort --skip "logexport/_version.py" -c function_app.py logexport/*
-	black --check --exclude "logexport/_version.py" function_app.py logexport
+	isort --skip "logexport/_version.py" -c function_app.py logexport/* tests/*
+	black --check --exclude "logexport/_version.py" function_app.py logexport tests
 
 .PHONY: fmt
 fmt:
-	isort --skip "logexport/_version.py" function_app.py logexport/*
-	black --exclude "logexport/_version.py" function_app.py logexport
+	isort --skip "logexport/_version.py" function_app.py logexport/* tests/*
+	black --exclude "logexport/_version.py" function_app.py logexport tests
 
 protos: push.proto buf.gen.yaml buf.yaml
 	buf generate .

--- a/logexport/_version.py
+++ b/logexport/_version.py
@@ -12,5 +12,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev18+g8e084a5.d20241105'
-__version_tuple__ = version_tuple = (0, 1, 'dev18', 'g8e084a5.d20241105')
+__version__ = version = '0.1.dev6+g85c8c17.d20241105'
+__version_tuple__ = version_tuple = (0, 1, 'dev6', 'g85c8c17.d20241105')

--- a/logexport/loki/client.py
+++ b/logexport/loki/client.py
@@ -20,6 +20,8 @@ class LokiClient:
         self.endpoint = url
         if username is not None and password is not None:
             self.auth = HTTPBasicAuth(username, password)
+        else:
+            self.auth = None
 
     def push(self, streams: Iterable[push_pb2.StreamAdapter]):
         push_request = push_pb2.PushRequest()
@@ -45,3 +47,11 @@ class LokiClient:
             raise HTTPError(
                 f"{res.status_code} Server Error for url: {res.url}: {res.text}"
             )
+
+    def query(self, query: str):
+        res = requests.get(
+            urllib.parse.urljoin(self.endpoint, "/loki/api/v1/query"),
+            params={"query": query},
+        )
+        res.raise_for_status()
+        return res.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ test = [
   "isort==5.13.2",
   "mypy==1.11.2",
   "pytest==8.3.3",
+  "testcontainers==4.8.2",
   "types-protobuf==5.28.3.20241030",
   "types-requests==2.32.0.20241016",
 ]

--- a/tests/loki_test_server.py
+++ b/tests/loki_test_server.py
@@ -1,0 +1,51 @@
+from typing import TYPE_CHECKING
+
+from requests import ConnectionError, HTTPError, get
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+
+from logexport.loki.client import LokiClient
+
+if TYPE_CHECKING:
+    from requests import Response
+
+
+# TODO: contribute to testcontainers modules
+class LokiContainer(DockerContainer):
+
+    def __init__(
+        self,
+        image: str = "grafana/loki:3.1.2",
+        port: int = 3100,
+        **kwargs,
+    ) -> None:
+        super().__init__(image, **kwargs)
+
+        self.port = port
+
+        self.with_exposed_ports(self.port)
+
+    @wait_container_is_ready(ConnectionError, HTTPError)
+    def _readiness_check(self) -> None:
+        """This is an internal method used to check if the Loki container
+        is healthy and ready to receive requests."""
+        url = f"{self.get_endpoint()}/ready"
+        response: Response = get(url)
+
+        # Loki will return HTTP 503 if it is not ready
+        response.raise_for_status()
+
+    def get_endpoint(self) -> str:
+        ip = self.get_container_host_ip()
+        port = self.get_exposed_port(self.port)
+        return f"http://{ip}:{port}"
+
+    def get_client(self) -> "LokiClient":
+        return LokiClient(self.get_endpoint())
+
+    def start(self) -> "LokiContainer":
+        """This method starts the Loki container and runs the readniness check
+        to verify that the container is ready to use."""
+        super().start()
+        self._readiness_check()
+        return self

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1,11 +1,21 @@
 import json
 from dataclasses import dataclass
-from logexport.deserialize import entry_from_event_record, get_timestamp, stream_from_event_body, VERSION_LABEL_KEY
+
+from logexport.deserialize import (
+    VERSION_LABEL_KEY,
+    entry_from_event_record,
+    get_timestamp,
+    stream_from_event_body,
+)
 from logexport.push import push_pb2
 
 
 def test_deserialization_message():
-    load = {"properties": {"key": "value"}, "time": "2024-06-05T10:47:31.676Z", "resourceId": "/SUBSCRIPTIONS/1234"}
+    load = {
+        "properties": {"key": "value"},
+        "time": "2024-06-05T10:47:31.676Z",
+        "resourceId": "/SUBSCRIPTIONS/1234",
+    }
     entry = entry_from_event_record(load, 0)
     assert json.loads(entry.line) == {
         "resourceId": "/SUBSCRIPTIONS/1234",
@@ -26,18 +36,31 @@ def test_deserialization_records():
         stream = stream_from_event_body(f)
         assert len(stream.entries) == 2
 
+
 def test_deserialization_timestamp():
     @dataclass
     class TestCase:
         field: str
-        input: dict 
+        input: dict
         expected: int
 
     test_cases = [
-            TestCase("timestamp", {"timestamp": "2024-06-05T10:47:31.676Z"}, "2024-06-05T10:47:31.676Z"),
-            TestCase("timeStamp", {"timeStamp": "2024-06-05T10:47:31.676Z"},"2024-06-05T10:47:31.676Z"),
-            TestCase("time", {"time": "2024-06-05T10:47:31.676Z"},"2024-06-05T10:47:31.676Z"),
-            TestCase("created", {"time": "2024-06-05T10:47:31.676Z"}, "2024-06-05T10:47:31.676Z"),
+        TestCase(
+            "timestamp",
+            {"timestamp": "2024-06-05T10:47:31.676Z"},
+            "2024-06-05T10:47:31.676Z",
+        ),
+        TestCase(
+            "timeStamp",
+            {"timeStamp": "2024-06-05T10:47:31.676Z"},
+            "2024-06-05T10:47:31.676Z",
+        ),
+        TestCase(
+            "time", {"time": "2024-06-05T10:47:31.676Z"}, "2024-06-05T10:47:31.676Z"
+        ),
+        TestCase(
+            "created", {"time": "2024-06-05T10:47:31.676Z"}, "2024-06-05T10:47:31.676Z"
+        ),
     ]
 
     for case in test_cases:

--- a/tests/test_loki_client.py
+++ b/tests/test_loki_client.py
@@ -1,0 +1,38 @@
+import pytest
+from loki_test_server import LokiContainer
+
+from logexport.loki.client import LokiClient
+from logexport.push import push_pb2
+
+loki = LokiContainer()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(request):
+    loki.start()
+
+    def remove_container():
+        loki.stop()
+
+    request.addfinalizer(remove_container)
+
+
+@pytest.fixture
+def client() -> LokiClient:
+    return loki.get_client()
+
+
+def test_push(client: LokiClient):
+    entry = push_pb2.EntryAdapter()
+    entry.line = "one line"
+    entry.timestamp.GetCurrentTime()
+
+    stream = push_pb2.StreamAdapter(
+        labels='{foo="bar"}',
+        entries=[entry],
+    )
+    client.push([stream])
+
+    res = client.query('{foo="bar"}')
+    assert res["status"] == "success"
+    assert res["data"]["result"][0]["values"][0][1] == "one line"


### PR DESCRIPTION
This change formats the test code and introduces a Loki testcontainer that's used in a simple Loki client push integration test.

Closes https://github.com/grafana/grafana-csp-app/issues/225