### PR TITLE
Do not parse floats as Decimals.

### DIFF
--- a/logexport/deserialize.py
+++ b/logexport/deserialize.py
@@ -46,7 +46,7 @@ def stream_from_event_body(
 
     stream_index: dict[str, push_pb2.StreamAdapter] = {}
     current_ts = time.time_ns()
-    for i in ijson.items(f, "records.item"):
+    for i in ijson.items(f, "records.item", use_float=True):
 
         # Each record should receive it's own unique timestamp.
         current_ts += 1

--- a/tests/record_issue_15.json
+++ b/tests/record_issue_15.json
@@ -1,0 +1,26 @@
+{
+    "records": [
+        {
+            "count": 17,
+            "total": 298,
+            "minimum": 2,
+            "maximum": 21,
+            "average": 17.5294117647059,
+            "resourceId": "/SUBSCRIPTIONS/<redacted_subscription_id>/RESOURCEGROUPS/RG-DIAGNOSTICS/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/<redacted_eventhub_namespace_name>",
+            "time": "2025-01-20T09:12:00.0000000Z",
+            "metricName": "IncomingRequests",
+            "timeGrain": "PT1M"
+        },
+        {
+            "count": 17,
+            "total": 286,
+            "minimum": 2,
+            "maximum": 20,
+            "average": 16.8235294117647,
+            "resourceId": "/SUBSCRIPTIONS/<redacted_subscription_id/RESOURCEGROUPS/RG-DIAGNOSTICS/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/<redacted_eventhub_namespace_name>",
+            "time": "2025-01-20T09:13:00.0000000Z",
+            "metricName": "IncomingRequests",
+            "timeGrain": "PT1M"
+        }
+    ]
+}


### PR DESCRIPTION
Since `Decimals` cannot be dumped as JSON we should deserialize them as floats.

Closes #15 