### PR TITLE
Use plural in job label

### DIFF
--- a/logexport/deserialize.py
+++ b/logexport/deserialize.py
@@ -79,7 +79,7 @@ def get_timestamp(load: dict) -> str | None:
 def create_labels_string(
     category: str | None, type: str | None, addional_labels: dict[str, str]
 ) -> str:
-    labels = 'job="integration/azure-logexport"'
+    labels = 'job="integrations/azure-logexport"'
 
     for key, value in addional_labels.items():
         labels += f',{key}="{value}"'

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -46,13 +46,13 @@ def test_deserialization_records():
         TestCase(
             "tests/record_sample.json",
             [
-                '{job="integration/azure-logexport",category="SQLSecurityAuditEvents"}',
-                '{job="integration/azure-logexport",category="SQLSecurityAuditEvents",type="AuditEvent"}',
+                '{job="integrations/azure-logexport",category="SQLSecurityAuditEvents"}',
+                '{job="integrations/azure-logexport",category="SQLSecurityAuditEvents",type="AuditEvent"}',
             ],
         ),
         TestCase(
             "tests/record_issue_15.json",
-            ['{job="integration/azure-logexport"}'],
+            ['{job="integrations/azure-logexport"}'],
         ),
     ]
     for case in test_cases:
@@ -95,20 +95,22 @@ def test_deserialization_timestamp():
 
 
 def test_create_labels_string():
-    assert create_labels_string(None, None, {}) == '{job="integration/azure-logexport"}'
+    assert (
+        create_labels_string(None, None, {}) == '{job="integrations/azure-logexport"}'
+    )
     assert (
         create_labels_string("cat1", "type1", {})
-        == '{job="integration/azure-logexport",category="cat1",type="type1"}'
+        == '{job="integrations/azure-logexport",category="cat1",type="type1"}'
     )
     assert (
         create_labels_string(None, "type1", {})
-        == '{job="integration/azure-logexport",type="type1"}'
+        == '{job="integrations/azure-logexport",type="type1"}'
     )
     assert (
         create_labels_string("cat1", None, {})
-        == '{job="integration/azure-logexport",category="cat1"}'
+        == '{job="integrations/azure-logexport",category="cat1"}'
     )
     assert (
         create_labels_string("cat1", None, {"cluster": "dev"})
-        == '{job="integration/azure-logexport",cluster="dev",category="cat1"}'
+        == '{job="integrations/azure-logexport",cluster="dev",category="cat1"}'
     )


### PR DESCRIPTION
This aligns with `integrations/<name>` which we usally use.