### PR TITLE
feat(): Add automatic environment label extraction from Azure resourceId

### DIFF
--- a/logexport/deserialize.py
+++ b/logexport/deserialize.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -12,10 +13,33 @@ from logexport.push import push_pb2
 VERSION_LABEL_KEY: Final[str] = "__grafana_azure_logexport_version__"
 
 
+def extract_env_from_resource_id(resource_id: str | None) -> str | None:
+    """Extract environment label from Azure resource ID based on resource group name.
+
+    Assumes the environment token is the trailing segment of the resource group
+    name (e.g. rg-ecos-compute-dev → dev, rg-ecos-api-prod → prod).
+    """
+    if not resource_id:
+        return None
+
+    match = re.search(r"/resourceGroups/([^/]+)", resource_id, re.IGNORECASE)
+    if not match:
+        return None
+
+    parts = [p for p in match.group(1).lower().split("-") if p]
+    if len(parts) < 2:
+        return None
+
+    if parts[-1] == "rg":
+        return None
+
+    return parts[-1]
+
+
 def entry_from_event_record(
     load: dict, current_ts_nanos: int
-) -> Tuple[str | None, str | None, push_pb2.EntryAdapter]:
-    """Returns the category and type of the event and the entry."""
+) -> Tuple[str | None, str | None, str | None, push_pb2.EntryAdapter]:
+    """Returns the category, type, env of the event and the entry."""
     entry = push_pb2.EntryAdapter()
 
     ts = get_timestamp(load)
@@ -26,8 +50,14 @@ def entry_from_event_record(
 
     entry.structuredMetadata.add(name=VERSION_LABEL_KEY, value=__version__)
 
-    if "resourceId" in load:
-        entry.structuredMetadata.add(name="resourceId", value=load["resourceId"])
+    resource_id = load.get("resourceId")
+    env = None
+    
+    if resource_id:
+        entry.structuredMetadata.add(name="resourceId", value=resource_id)
+        env = extract_env_from_resource_id(resource_id)
+        if env is not None:
+            entry.structuredMetadata.add(name="env", value=env)
 
     if "correlationId" in load:
         entry.structuredMetadata.add(name="correlationId", value=load["correlationId"])
@@ -38,7 +68,7 @@ def entry_from_event_record(
     if typ is None and load.get("ProductName") == "Microsoft Defender for Cloud":
         typ = "Alert/" + (load.get("AlertType") or "Unknown")
 
-    return load.get("category"), typ, entry
+    return load.get("category"), typ, env, entry
 
 
 def stream_from_event_body(
@@ -59,14 +89,14 @@ def stream_from_event_body(
     for record in get_records(data):
         # Each record should receive it's own unique timestamp.
         current_ts += 1
-        (category, type, entry) = entry_from_event_record(record, current_ts)
+        (category, type, env, entry) = entry_from_event_record(record, current_ts)
 
         for i in config.filter.apply(record):
             updated = push_pb2.EntryAdapter()
             updated.CopyFrom(entry)
             updated.line = json.dumps(i)
 
-            labels = create_labels_string(category, type, config.additional_labels)
+            labels = create_labels_string(category, type, env, config.additional_labels)
             stream = stream_index.setdefault(
                 labels, push_pb2.StreamAdapter(labels=labels)
             )
@@ -100,16 +130,21 @@ def get_timestamp(load: dict) -> str | None:
 
 
 def create_labels_string(
-    category: str | None, type: str | None, addional_labels: dict[str, str]
+    category: str | None, type: str | None, env: str | None, addional_labels: dict[str, str]
 ) -> str:
-    labels = 'job="integrations/azure-logexport"'
+    # Build labels deterministically and avoid duplicate env
+    parts: list[str] = ['job="integrations/azure-logexport"']
 
     for key, value in addional_labels.items():
-        labels += f',{key}="{value}"'
+        if env is not None and key == "env":
+            continue
+        parts.append(f'{key}="{value}"')
 
     if category is not None:
-        labels += f',category="{category}"'
+        parts.append(f'category="{category}"')
     if type is not None:
-        labels += f',type="{type}"'
+        parts.append(f'type="{type}"')
+    if env is not None:
+        parts.append(f'env="{env}"')
 
-    return "{" + labels + "}"
+    return "{" + ",".join(parts) + "}"


### PR DESCRIPTION
### What’s changed

This PR introduces automatic environment detection from Azure resourceId and propagates it as a structured metadata field and Loki label.

### Key updates:

Added extract_env_from_resource_id() to parse env from resource group naming convention (e.g., rg-ecos-api-prod → prod).

Extended entry_from_event_record() to return (category, type, env, entry).

Added env to structured metadata and label generation.

Updated create_labels_string() to avoid duplicate env labels and ensure deterministic label ordering.

### Why this is needed

Currently, environment labeling is manual and inconsistent across log sources.
This change enables automatic env tagging directly from Azure resource metadata, improving:

Query filtering in Grafana/Loki

Multi-environment observability

Cost attribution and troubleshooting workflows

#### Assumptions

Resource groups follow the naming pattern: rg-<service>-<component>-<env>

The last segment represents the environment (excluding trailing rg)

Backward Compatibility

No breaking changes to existing label logic

If env cannot be parsed, behavior remains unchanged

Explicit additional_labels["env"] still overrides auto-detected env

Example

Input Resource ID

/subscriptions/.../resourceGroups/rg-ecos-compute-dev/providers/...


#### Generated Label

`env="dev"`
