### PR TITLE
fix: repair JSON syntax error and add HTTPS-only policy compliance

### DIFF
--- a/azdeploy.json
+++ b/azdeploy.json
@@ -117,7 +117,7 @@
         "capacity": 1
       },
       "properties": {
-        "minimumTlsVersion": "1.2"
+        "minimumTlsVersion": "1.2",
         "isAutoInflateEnabled": false,
         "maximumThroughputUnits": 0
       }
@@ -199,9 +199,13 @@
       "kind": "functionapp,linux",
       "properties": {
         "reserved": true,
+        "httpsOnly": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
         "siteConfig": {
           "linuxFxVersion": "python|3.11",
+          "minTlsVersion": "1.2",
+          "scmMinTlsVersion": "1.2",
+          "ftpsState": "Disabled",
           "appSettings": [
             {
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",


### PR DESCRIPTION
## Summary
- Fix missing comma in EventHub namespace properties (line 120) that caused ARM template parse failure
- Add `httpsOnly: true` to the Function App resource to satisfy Azure "CSF Secure Configuration" policy requiring HTTPS-only access
- Add `minTlsVersion`, `scmMinTlsVersion`, and `ftpsState` security hardening to siteConfig

## Test plan
- [ ] Validate JSON parses correctly (`python -c "import json; json.load(open('azdeploy.json'))"`)
- [ ] Deploy ARM template to Azure and confirm no `RequestDisallowedByPolicy` error
- [ ] Verify Function App is HTTPS-only after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://github.com/grafana/azure_eventhub_to_loki/issues/92