### PR TITLE
fix: upgrade storage account from GPv1 to GPv2

### DIFF
--- a/azdeploy.json
+++ b/azdeploy.json
@@ -160,7 +160,7 @@
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
-      "kind": "Storage"
+      "kind": "StorageV2"
     },
     {
       "type": "Microsoft.Web/serverfarms",


### PR DESCRIPTION
## Summary
- Upgrade storage account `kind` from `Storage` (GPv1) to `StorageV2` (GPv2)
- Azure GPv1 storage accounts are being retired on **2026-10-13** — this change prevents service interruptions and potential billing changes after that date

## Test plan
- [ ] Deploy ARM template to Azure and confirm storage account is created as GPv2
- [ ] Verify Function App continues to work with the upgraded storage account kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)