### PR TITLE
Fix EventHub TLS enforcement, Basic SKU retention limit, and modernize storage account

### DIFF
--- a/azdeploy.json
+++ b/azdeploy.json
@@ -103,12 +103,13 @@
     "eventHubAuthorizationRuleName": "[parameters('functionAppName')]",
     "eventHubName": "[parameters('eventHubName')]",
     "eventHubNamespaceName": "[parameters('functionAppName')]",
-    "storageAccountName": "[format('logexport{0}', uniqueString(resourceGroup().id))]"
+    "storageAccountName": "[format('logexport{0}', uniqueString(resourceGroup().id))]",
+    "eventHubMessageRetentionInDays": "[if(equals(parameters('eventHubSku'), 'Basic'), 1, 7)]"
   },
   "resources": [
     {
       "type": "Microsoft.EventHub/namespaces",
-      "apiVersion": "2021-11-01",
+      "apiVersion": "2024-01-01",
       "name": "[variables('eventHubNamespaceName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -127,7 +128,7 @@
       "apiVersion": "2021-11-01",
       "name": "[format('{0}/{1}', variables('eventHubNamespaceName'), variables('eventHubName'))]",
       "properties": {
-        "messageRetentionInDays": 7,
+        "messageRetentionInDays": "[variables('eventHubMessageRetentionInDays')]",
         "partitionCount": 1,
         "messageTimestampDescription": {
           "timestampType": "LogAppend"
@@ -160,7 +161,12 @@
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
-      "kind": "Storage"
+      "kind": "StorageV2",
+      "properties": {
+        "minimumTlsVersion": "TLS1_2",
+        "supportsHttpsTrafficOnly": true,
+        "allowBlobPublicAccess": false
+      }
     },
     {
       "type": "Microsoft.Web/serverfarms",


### PR DESCRIPTION
This PR fixes three issues in `azdeploy.json`:

- **EventHub TLS enforcement not applied**: bumped the `Microsoft.EventHub/namespaces`
  apiVersion from `2021-11-01` to `2024-01-01`. `minimumTlsVersion` is only enforced
  by the resource provider on api-version `2022-01-01-preview` or later; on
  `2021-11-01` the property is silently ignored and the namespace stays on TLS 1.0.

- **Deployment fails when `eventHubSku` = Basic**: `messageRetentionInDays` was
  hardcoded to `7`, but the Basic tier only supports up to 1 day of retention.
  Added a SKU-aware variable so retention is `1` for Basic and `7` for Standard.

- **Storage account modernization**: switched `kind` from `Storage` (GPv1) to
  `StorageV2`, since GPv1 is retiring October 13, 2026 and new GPv1 account
  creation was already blocked as of Q1 2026. Also added explicit security
  hardening that wasn't set before: `minimumTlsVersion: TLS1_2`,
  `supportsHttpsTrafficOnly: true`, `allowBlobPublicAccess: false`.

No changes to the Function App code or existing deployment parameters. This
only touches `azdeploy.json`.